### PR TITLE
Add 'limit_parallel' decorator.

### DIFF
--- a/doc/source/tutorial.rst
+++ b/doc/source/tutorial.rst
@@ -41,3 +41,11 @@ In the following example, the :class:`.BatchSubmitter` wraps a function which mu
 
 .. include:: ../../examples/batch_submit.py
     :code: python
+
+limit_parallel
+--------------
+
+The decorator :func:`.limit_parallel` can be used to limit the number of parallel calls to a given function. This can be useful in cases where a function uses a lot of resources, and so only a limited number can run concurrently.
+
+.. include:: ../../examples/limit_parallel.py
+    :code: python

--- a/examples/limit_parallel.py
+++ b/examples/limit_parallel.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+"""
+Example for using the limit_parallel decorator.
+"""
+
+import asyncio
+
+import numpy as np
+from fsc.async_tools import limit_parallel
+
+
+async def use_some_memory():
+    """
+    Dummy function which initializes a large array.
+    """
+    x = np.ones(shape=(10000000, ))
+    await asyncio.sleep(3.)
+    del x
+
+
+def launch_many(coro_func):
+    """
+    Launch the given coroutine function one hundred times.
+    """
+    loop = asyncio.get_event_loop()
+    return loop.run_until_complete(
+        asyncio.
+        gather(*[asyncio.ensure_future(coro_func()) for _ in range(100)])
+    )
+
+
+if __name__ == '__main__':
+    print('Without limiter...')
+    launch_many(use_some_memory)
+    print('With limiter...')
+    launch_many(limit_parallel(10)(use_some_memory))

--- a/fsc/async_tools/__init__.py
+++ b/fsc/async_tools/__init__.py
@@ -12,5 +12,6 @@ from ._version import __version__
 from ._periodic_task import *
 from ._wrap_to_coroutine import *
 from ._batch_submit import *
+from ._limit_parallel import *
 
-__all__ = _periodic_task.__all__ + _wrap_to_coroutine.__all__ + _batch_submit.__all__  # pylint: disable=undefined-variable
+__all__ = _periodic_task.__all__ + _wrap_to_coroutine.__all__ + _batch_submit.__all__ + _limit_parallel.__all__  # pylint: disable=undefined-variable

--- a/fsc/async_tools/_limit_parallel.py
+++ b/fsc/async_tools/_limit_parallel.py
@@ -1,0 +1,44 @@
+"""
+Defines a decorator that limits the number of parallel calls to a function
+or coroutine.
+"""
+
+import asyncio
+from functools import wraps
+
+from fsc.export import export
+
+from . import wrap_to_coroutine
+
+
+@export
+def limit_parallel(max_num_parallel, sleep_time=0.):
+    """
+    Decorator that limits the number of parallel calls to a function or coroutine.
+
+    Arguments
+    ---------
+    max_num_parallel : int
+        The maximum number of calls which can run in parallel.
+    sleep_time : float, optional
+        Minimum wait time between checking if the function can be called.
+    """
+
+    def decorator(func):  # pylint: disable=missing-docstring
+        count = 0
+
+        func_wrapped = wrap_to_coroutine(func)
+
+        @wraps(func)
+        async def inner(*args, **kwargs):  # pylint: disable=missing-docstring
+            nonlocal count
+            while count >= max_num_parallel:
+                await asyncio.sleep(sleep_time)
+            count += 1
+            res = await func_wrapped(*args, **kwargs)
+            count -= 1
+            return res
+
+        return inner
+
+    return decorator

--- a/fsc/async_tools/_limit_parallel.py
+++ b/fsc/async_tools/_limit_parallel.py
@@ -12,7 +12,7 @@ from . import wrap_to_coroutine
 
 
 @export
-def limit_parallel(max_num_parallel, sleep_time=0.):
+def limit_parallel(max_num_parallel):
     """
     Decorator that limits the number of parallel calls to a function or coroutine.
 
@@ -20,25 +20,20 @@ def limit_parallel(max_num_parallel, sleep_time=0.):
     ---------
     max_num_parallel : int
         The maximum number of calls which can run in parallel.
-    sleep_time : float, optional
-        Minimum wait time between checking if the function can be called.
     """
 
     def decorator(func):  # pylint: disable=missing-docstring
-        count = 0
-
+        semaphore = asyncio.Semaphore(value=max_num_parallel)
         func_wrapped = wrap_to_coroutine(func)
 
         @wraps(func)
         async def inner(*args, **kwargs):  # pylint: disable=missing-docstring
-            nonlocal count
-            while count >= max_num_parallel:
-                await asyncio.sleep(sleep_time)
-            count += 1
+            nonlocal semaphore
+            await semaphore.acquire()
             try:
                 res = await func_wrapped(*args, **kwargs)
             finally:
-                count -= 1
+                semaphore.release()
             return res
 
         return inner

--- a/fsc/async_tools/_limit_parallel.py
+++ b/fsc/async_tools/_limit_parallel.py
@@ -35,8 +35,10 @@ def limit_parallel(max_num_parallel, sleep_time=0.):
             while count >= max_num_parallel:
                 await asyncio.sleep(sleep_time)
             count += 1
-            res = await func_wrapped(*args, **kwargs)
-            count -= 1
+            try:
+                res = await func_wrapped(*args, **kwargs)
+            finally:
+                count -= 1
             return res
 
         return inner

--- a/tests/test_limit_parallel.py
+++ b/tests/test_limit_parallel.py
@@ -53,7 +53,9 @@ def test_limit_parallel(count_coro, max_num_parallel):  # pylint: disable=redefi
     loop = asyncio.get_event_loop()
     assert get_max_count(count_coro, loop) > 10
     limited_coro = limit_parallel(max_num_parallel)(count_coro)
-    assert get_max_count(limited_coro, loop) < max_num_parallel
+    assert max_num_parallel // 2 <= get_max_count(
+        limited_coro, loop
+    ) < max_num_parallel
 
 
 def test_with_exception():

--- a/tests/test_limit_parallel.py
+++ b/tests/test_limit_parallel.py
@@ -1,0 +1,56 @@
+"""
+Tests for the ``limit_parallel`` decorator.
+"""
+
+import asyncio
+
+import pytest
+
+from fsc.async_tools import limit_parallel
+
+
+@pytest.fixture
+def count_coro():
+    """
+    Returns a coroutine function that returns the number of other instances
+    that are currently running.
+    """
+    count = 0
+
+    async def inner():  # pylint: disable=missing-docstring
+        nonlocal count
+        res = count
+        count += 1
+        await asyncio.sleep(0.)
+        count -= 1
+        return res
+
+    return inner
+
+
+def get_max_count(coro_func, loop, num_calls=100):
+    """
+    Get the maximum result amongst a number of calls to a given coroutine function.
+    """
+    return max(
+        loop.run_until_complete(
+            asyncio.gather(
+                *[
+                    asyncio.ensure_future(coro_func())
+                    for _ in range(num_calls)
+                ]
+            )
+        )
+    )
+
+
+@pytest.mark.parametrize('max_num_parallel', [1, 5, 20])
+def test_limit_parallel(count_coro, max_num_parallel):  # pylint: disable=redefined-outer-name
+    """
+    Test the limit_parallel decorator by checking that the number of parallel
+    calls does not exceed the maximum.
+    """
+    loop = asyncio.get_event_loop()
+    assert get_max_count(count_coro, loop) > 10
+    limited_coro = limit_parallel(max_num_parallel)(count_coro)
+    assert get_max_count(limited_coro, loop) < max_num_parallel


### PR DESCRIPTION
Limits the number of calls to a coroutine/function which are done in parallel. If there are more than a given number of calls, it waits before calling the function.